### PR TITLE
Add symbols for event mons and refactor seteventmon

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1891,8 +1891,8 @@
 
 	@ Creates an "event legal" Pokémon for an encounter
 	.macro seteventmon species:req, level:req, item=ITEM_NONE
-	setvar VAR_0x8004, \species
-	setvar VAR_0x8005, \level
-	setvar VAR_0x8006, \item
-	special CreateEventLegalEnemyMon
+	.byte 0xe3
+	.2byte \species
+	.byte \level
+	.2byte \item
 	.endm

--- a/data/maps/BirthIsland_Exterior/scripts.inc
+++ b/data/maps/BirthIsland_Exterior/scripts.inc
@@ -85,6 +85,7 @@ BirthIsland_Exterior_EventScript_Deoxys::
 	delay 40
 	waitmoncry
 	setvar VAR_LAST_TALKED, LOCALID_DEOXYS
+Archipelago_Target_Static_Encounter_FLAG_HIDE_DEOXYS::
 	seteventmon SPECIES_DEOXYS, 30
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle

--- a/data/maps/FarawayIsland_Interior/scripts.inc
+++ b/data/maps/FarawayIsland_Interior/scripts.inc
@@ -129,6 +129,7 @@ FarawayIsland_Interior_EventScript_Mew::
 	special DestroyMewEmergingGrassSprite
 	delay 40
 	waitmoncry
+Archipelago_Target_Static_Encounter_FLAG_HIDE_MEW::
 	seteventmon SPECIES_MEW, 30
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle

--- a/data/maps/NavelRock_Bottom/scripts.inc
+++ b/data/maps/NavelRock_Bottom/scripts.inc
@@ -53,6 +53,7 @@ NavelRock_Bottom_EventScript_Lugia::
 	playmoncry SPECIES_LUGIA, CRY_MODE_ENCOUNTER
 	waitmoncry
 	delay 20
+Archipelago_Target_Static_Encounter_FLAG_HIDE_LUGIA::
 	seteventmon SPECIES_LUGIA, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle

--- a/data/maps/NavelRock_Top/scripts.inc
+++ b/data/maps/NavelRock_Top/scripts.inc
@@ -57,6 +57,7 @@ NavelRock_Top_EventScript_HoOh::
 	applymovement LOCALID_HO_OH, NavelRock_Top_Movement_HoOhApproach
 	waitmovement 0
 	special RemoveCameraObject
+Archipelago_Target_Static_Encounter_FLAG_HIDE_HO_OH::
 	seteventmon SPECIES_HO_OH, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle

--- a/data/maps/SouthernIsland_Interior/scripts.inc
+++ b/data/maps/SouthernIsland_Interior/scripts.inc
@@ -105,10 +105,12 @@ SouthernIsland_Interior_EventScript_Sign::
 	end
 
 SouthernIsland_Interior_EventScript_SetLatiosBattleVars::
+Archipelago_Target_Static_Encounter_FLAG_HIDE_SOUTHERN_ISLAND_UNCHOSEN_EON_DUO_MON_LATIOS::
 	seteventmon SPECIES_LATIOS, 50, ITEM_SOUL_DEW
 	return
 
 SouthernIsland_Interior_EventScript_SetLatiasBattleVars::
+Archipelago_Target_Static_Encounter_FLAG_HIDE_SOUTHERN_ISLAND_UNCHOSEN_EON_DUO_MON_LATIAS::
 	seteventmon SPECIES_LATIAS, 50, ITEM_SOUL_DEW
 	return
 

--- a/data/maps/SouthernIsland_Interior/scripts.inc
+++ b/data/maps/SouthernIsland_Interior/scripts.inc
@@ -105,12 +105,12 @@ SouthernIsland_Interior_EventScript_Sign::
 	end
 
 SouthernIsland_Interior_EventScript_SetLatiosBattleVars::
-Archipelago_Target_Static_Encounter_FLAG_HIDE_SOUTHERN_ISLAND_UNCHOSEN_EON_DUO_MON_LATIOS::
+Archipelago_Target_Static_Encounter_FLAG_DUMMY_LATIOS::
 	seteventmon SPECIES_LATIOS, 50, ITEM_SOUL_DEW
 	return
 
 SouthernIsland_Interior_EventScript_SetLatiasBattleVars::
-Archipelago_Target_Static_Encounter_FLAG_HIDE_SOUTHERN_ISLAND_UNCHOSEN_EON_DUO_MON_LATIAS::
+Archipelago_Target_Static_Encounter_FLAG_DUMMY_LATIAS::
 	seteventmon SPECIES_LATIAS, 50, ITEM_SOUL_DEW
 	return
 

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -227,6 +227,7 @@ gScriptCmdTable::
 	.4byte ScrCmd_warpwhitefade             @ 0xe0
 	.4byte ScrCmd_buffercontestname         @ 0xe1
 	.4byte ScrCmd_bufferitemnameplural      @ 0xe2
+	.4byte ScrCmd_seteventmon               @ 0xe3
 
 gScriptCmdTableEnd::
 	.4byte ScrCmd_nop

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -41,8 +41,10 @@
 #define FLAG_TEMP_1F     (TEMP_FLAGS_START + 0x1F)
 #define TEMP_FLAGS_END   FLAG_TEMP_1F
 
-#define FLAG_UNUSED_0x020    0x20 // Unused Flag
-#define FLAG_UNUSED_0x021    0x21 // Unused Flag
+// TODO: fix these for legendary hunt goal
+#define FLAG_DUMMY_LATIOS    0x20
+#define FLAG_DUMMY_LATIAS    0x21
+
 #define FLAG_UNUSED_0x022    0x22 // Unused Flag
 #define FLAG_UNUSED_0x023    0x23 // Unused Flag
 #define FLAG_UNUSED_0x024    0x24 // Unused Flag

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -407,7 +407,7 @@ bool8 ShouldIgnoreDeoxysForm(u8 caseId, u8 battlerId);
 void SetDeoxysStats(void);
 u16 GetUnionRoomTrainerPic(void);
 u16 GetUnionRoomTrainerClass(void);
-void CreateEventLegalEnemyMon(void);
+void CreateEventLegalEnemyMon(u16 species, u8 level, u16 item);
 void CalculateMonStats(struct Pokemon *mon);
 void BoxMonToMon(const struct BoxPokemon *src, struct Pokemon *dest);
 u8 GetLevelFromMonExp(struct Pokemon *mon);

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -512,6 +512,21 @@ void BattleSetup_StartLatiBattle(void)
     TryUpdateGymLeaderRematchFromWild();
 }
 
+const u8 lengendary_transitions[] = {
+    B_TRANSITION_GROUDON,
+    B_TRANSITION_KYOGRE,
+    B_TRANSITION_RAYQUAZA,
+    B_TRANSITION_BLUR,
+    B_TRANSITION_GRID_SQUARES
+};
+const u16 lengendary_music[] = {
+    MUS_VS_KYOGRE_GROUDON,
+    MUS_VS_RAYQUAZA,
+    MUS_RG_VS_DEOXYS,
+    MUS_RG_VS_LEGEND,
+    MUS_VS_MEW
+};
+
 void BattleSetup_StartLegendaryBattle(void)
 {
     LockPlayerFieldControls();
@@ -520,7 +535,6 @@ void BattleSetup_StartLegendaryBattle(void)
 
     switch (GetMonData(&gEnemyParty[0], MON_DATA_SPECIES, NULL))
     {
-    default:
     case SPECIES_GROUDON:
         gBattleTypeFlags |= BATTLE_TYPE_GROUDON;
         CreateBattleStartTask(B_TRANSITION_GROUDON, MUS_VS_KYOGRE_GROUDON);
@@ -543,6 +557,8 @@ void BattleSetup_StartLegendaryBattle(void)
     case SPECIES_MEW:
         CreateBattleStartTask(B_TRANSITION_GRID_SQUARES, MUS_VS_MEW);
         break;
+    default:
+        CreateBattleStartTask(lengendary_transitions[Random2()%5], lengendary_music[Random2()%5]);
     }
 
     IncrementGameStat(GAME_STAT_TOTAL_BATTLES);

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -512,14 +512,14 @@ void BattleSetup_StartLatiBattle(void)
     TryUpdateGymLeaderRematchFromWild();
 }
 
-const u8 lengendary_transitions[] = {
+const u8 legendary_transitions[] = {
     B_TRANSITION_GROUDON,
     B_TRANSITION_KYOGRE,
     B_TRANSITION_RAYQUAZA,
     B_TRANSITION_BLUR,
     B_TRANSITION_GRID_SQUARES
 };
-const u16 lengendary_music[] = {
+const u16 legendary_music[] = {
     MUS_VS_KYOGRE_GROUDON,
     MUS_VS_RAYQUAZA,
     MUS_RG_VS_DEOXYS,
@@ -558,7 +558,7 @@ void BattleSetup_StartLegendaryBattle(void)
         CreateBattleStartTask(B_TRANSITION_GRID_SQUARES, MUS_VS_MEW);
         break;
     default:
-        CreateBattleStartTask(lengendary_transitions[Random2()%5], lengendary_music[Random2()%5]);
+        CreateBattleStartTask(legendary_transitions[Random2()%5], legendary_music[Random2()%5]);
     }
 
     IncrementGameStat(GAME_STAT_TOTAL_BATTLES);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2763,19 +2763,15 @@ u16 GetUnionRoomTrainerClass(void)
     return gFacilityClassToTrainerClass[gUnionRoomFacilityClasses[arrId]];
 }
 
-void CreateEventLegalEnemyMon(void)
+void CreateEventLegalEnemyMon(u16 species, u8 level, u16 item)
 {
-    s32 species = gSpecialVar_0x8004;
-    s32 level = gSpecialVar_0x8005;
-    s32 itemId = gSpecialVar_0x8006;
-
     ZeroEnemyPartyMons();
     CreateEventLegalMon(&gEnemyParty[0], species, level, USE_RANDOM_IVS, FALSE, 0, OT_ID_PLAYER_ID, 0);
-    if (itemId)
+    if (item)
     {
         u8 heldItem[2];
-        heldItem[0] = itemId;
-        heldItem[1] = itemId >> 8;
+        heldItem[0] = item;
+        heldItem[1] = item >> 8;
         SetMonData(&gEnemyParty[0], MON_DATA_HELD_ITEM, heldItem);
     }
 }

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1879,6 +1879,16 @@ bool8 ScrCmd_setwildbattle(struct ScriptContext *ctx)
     return FALSE;
 }
 
+bool8 ScrCmd_seteventmon(struct ScriptContext *ctx)
+{
+    u16 species = ScriptReadHalfword(ctx);
+    u8 level = ScriptReadByte(ctx);
+    u16 item = ScriptReadHalfword(ctx);
+
+    CreateEventLegalEnemyMon(species, level, item);
+    return FALSE;
+}
+
 bool8 ScrCmd_dowildbattle(struct ScriptContext *ctx)
 {
     BattleSetup_StartScriptedWildBattle();

--- a/tools/extractor/extractor.cpp
+++ b/tools/extractor/extractor.cpp
@@ -7,6 +7,7 @@
 #include <set>
 #include <string>
 #include <regex>
+#include <sstream>
 
 #include <json.hpp>
 using json = nlohmann::json;
@@ -46,6 +47,11 @@ int main (int argc, char *argv[])
     // ------------------------------------------------------------------------
     std::cout << "Reading symbols..." << std::endl;
     std::ifstream symbol_map_file(root_dir / "pokeemerald-archipelago.sym");
+    if (symbol_map_file.fail())
+    {
+        fprintf(stderr, "Could not find pokeemerald-archipelago.sym\n");
+        exit(1);
+    }
     std::regex symbol_map_regex("^([0-9a-fA-F]+) [lg] [0-9a-fA-F]+ ([a-zA-Z0-9_]+)$");
     std::map<std::string, uint32_t> symbol_map;
 


### PR DESCRIPTION
There is currently a problem with this PR.

Latios and Latias use two different `seteventmon` commands, but they share the same flag. I've just appended `_LATIOS` and `_LATIAS` for now (which fails extraction because those flags don't exist). What do you think the best solution is? Create two more flags, one for each and set them accordingly?

I tested this on multiple event encounters.